### PR TITLE
made compatible with Python 3.x: print statements and exception syntax

### DIFF
--- a/imageProc.py
+++ b/imageProc.py
@@ -34,7 +34,7 @@ def fixDefects(da, hlen=5, interpFunc=setPixels,
     x = np.arange(0, nx)
     for y in range(ny):
         if verbose:
-            print "%d\r" % y,; sys.stdout.flush()
+            print("%d\r" % y), sys.stdout.flush()
         
         bad = (da.mask[y, x] & badMask) != 0
         xbad = x[bad]
@@ -63,4 +63,4 @@ def fixDefects(da, hlen=5, interpFunc=setPixels,
             interpFunc(da, xind, y, good)
 
     if verbose:
-        print ""
+        print("")

--- a/utils.py
+++ b/utils.py
@@ -42,7 +42,7 @@ def getMpFigure(fig=None, clear=True):
         if _mpFigures.has_key(i):
             try:
                 lift(_mpFigures[i])
-            except Exception, e:
+            except Exception as e:
                 del _mpFigures[i]
                 
         if not _mpFigures.has_key(i):
@@ -57,7 +57,7 @@ def getMpFigure(fig=None, clear=True):
                 _show(self)
                 try:
                     lift(self)
-                except Exception, e:
+                except Exception as e:
                     pass
             # create a bound method
             import types


### PR DESCRIPTION
Hi!

This affects utils for workbook II, small updates to make it Python 3.x compatible

Chris 
